### PR TITLE
Use variables as column names

### DIFF
--- a/R/read_wasserportal.R
+++ b/R/read_wasserportal.R
@@ -182,7 +182,9 @@ merge_raw_results_single <- function(dfs, variables, include_raw_time)
 
   backbone$row <- seq_len(nrow(backbone))
 
-  data_frames <- c(list(base = backbone), dfs)
+  data_frames <- c(list(backbone), dfs)
+
+  names(data_frames) <- c("base", variables)
 
   result <- kwb.utils::mergeAll(
     data_frames, by = keys, all.x = TRUE, dbg = FALSE


### PR DESCRIPTION
Add variables as list names in merge_raw_results_single(), so they can be used b be used by mergeAll(). Before columns were named with ".x", ".y", etc.