### PR TITLE
Use ThingsBoard's X-Authorization header instead of standard Authoriz…

### DIFF
--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -305,7 +305,7 @@ tb_get_or_create_device <- function(device_name, device_type, api_key, host)
   lookup <- tryCatch(
     httr2::request(sprintf("%s/api/tenant/devices", host)) |>
       httr2::req_url_query(deviceName = device_name) |>
-      httr2::req_auth_bearer_token(api_key) |>
+      httr2::req_headers(`X-Authorization` = paste("Bearer", api_key)) |>
       httr2::req_error(is_error = function(resp) {
         httr2::resp_status(resp) >= 500L
       }) |>
@@ -319,7 +319,7 @@ tb_get_or_create_device <- function(device_name, device_type, api_key, host)
   }
 
   created <- httr2::request(sprintf("%s/api/device", host)) |>
-    httr2::req_auth_bearer_token(api_key) |>
+    httr2::req_headers(`X-Authorization` = paste("Bearer", api_key)) |>
     httr2::req_body_json(
       list(name = device_name, type = device_type),
       auto_unbox = TRUE
@@ -345,7 +345,7 @@ tb_get_device_access_token <- function(device_id, api_key, host)
   resp <- httr2::request(
     sprintf("%s/api/device/%s/credentials", host, device_id)
   ) |>
-    httr2::req_auth_bearer_token(api_key) |>
+    httr2::req_headers(`X-Authorization` = paste("Bearer", api_key)) |>
     httr2::req_perform() |>
     httr2::resp_body_json()
 


### PR DESCRIPTION
…ation

The ThingsBoard REST API expects the JWT/API-key bearer token in the non-standard 'X-Authorization: Bearer <token>' header. httr2's req_auth_bearer_token() sets the RFC-compliant 'Authorization' header, which ThingsBoard silently ignores -- the first call to GET /api/tenant/devices then returns HTTP 401 Unauthorized and tb_setup_devices() aborts.

Replace all three req_auth_bearer_token() calls in tb_get_or_create_device() and tb_get_device_access_token() with an explicit req_headers('X-Authorization' = ...).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/54)
<!-- Reviewable:end -->
