### PR TITLE
Diagnose station selection and add history-days cap for telemetry

### DIFF
--- a/.github/workflows/thingsboard-push.yaml
+++ b/.github/workflows/thingsboard-push.yaml
@@ -11,9 +11,13 @@ on:
   workflow_dispatch:
     inputs:
       station_ids:
-        description: 'Comma-separated Messstellennummer values to push'
+        description: 'Comma-separated Messstellennummer values to push (empty = auto)'
         required: false
-        default: '5803900,5805600,5867000,5826200,5824300'
+        default: ''
+      history_days:
+        description: 'Push only the most recent N days per station (0 = all)'
+        required: false
+        default: '30'
 
 name: thingsboard-push
 
@@ -25,6 +29,7 @@ jobs:
       TB_HOST: ${{ secrets.TB_HOST }}
       TB_API_KEY: ${{ secrets.TB_API_KEY }}
       TB_STATION_IDS: ${{ github.event.inputs.station_ids }}
+      TB_HISTORY_DAYS: ${{ github.event.inputs.history_days || '30' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/inst/scripts/push_to_thingsboard.R
+++ b/inst/scripts/push_to_thingsboard.R
@@ -35,6 +35,8 @@
 #                     "wasserportal-gw-".
 #   TB_MAX_DEVICES    Maximum number of devices to set up. Default 5
 #                     (ThingsBoard Cloud free tier limit).
+#   TB_HISTORY_DAYS   Limit telemetry to the most recent N days per
+#                     station. Default 0 (= push all history).
 
 stopifnot(
   nzchar(Sys.getenv("TB_HOST")),
@@ -49,6 +51,11 @@ base_url <- sub(
 device_prefix <- Sys.getenv("TB_DEVICE_PREFIX", "wasserportal-gw-")
 
 max_devices <- as.integer(Sys.getenv("TB_MAX_DEVICES", "5"))
+
+# Limit telemetry to the most recent N days per station. Set to 0 to push
+# all history. Useful while diagnosing whether the ThingsBoard Cloud free
+# tier silently rejects historical timestamps with HTTP 500.
+history_days <- as.integer(Sys.getenv("TB_HISTORY_DAYS", "0"))
 
 read_json <- function(path) {
   jsonlite::fromJSON(paste0(base_url, "/", path))
@@ -99,9 +106,27 @@ if (nzchar(env_ids)) {
     length(station_ids)
   ))
 } else {
-  both_ids <- intersect(gwl_master$Nummer, gwq_master$Nummer)
-  both_ids <- intersect(both_ids, gwl_data$Messstellennummer)
-  both_ids <- intersect(both_ids, gwq_data$Messstellennummer)
+  master_intersect <- intersect(gwl_master$Nummer, gwq_master$Nummer)
+  with_gwl <- intersect(master_intersect, unique(gwl_data$Messstellennummer))
+  with_both <- intersect(with_gwl, unique(gwq_data$Messstellennummer))
+
+  message(sprintf(
+    paste0(
+      "Station counts:\n",
+      "  gwl_master   = %d\n",
+      "  gwq_master   = %d\n",
+      "  master_intersect (both files)     = %d\n",
+      "  + present in stations_gwl_data    = %d\n",
+      "  + present in stations_gwq_data    = %d"
+    ),
+    length(unique(gwl_master$Nummer)),
+    length(unique(gwq_master$Nummer)),
+    length(master_intersect),
+    length(with_gwl),
+    length(with_both)
+  ))
+
+  both_ids <- with_both
 
   message(sprintf(
     "%d stations have both gwl and gwq data; scoring ...",
@@ -215,6 +240,16 @@ for (station_id in station_ids) {
 push_telemetry_subset <- function(data, label) {
   message(sprintf("\n=== %s ===", label))
   data <- data[data$Messstellennummer %in% station_ids, , drop = FALSE]
+
+  if (history_days > 0L) {
+    cutoff <- Sys.Date() - history_days
+    before <- nrow(data)
+    data <- data[as.Date(data$Datum) >= cutoff, , drop = FALSE]
+    message(sprintf(
+      "  TB_HISTORY_DAYS=%d: kept %d/%d rows (>= %s)",
+      history_days, nrow(data), before, format(cutoff)
+    ))
+  }
 
   if (nrow(data) == 0L) {
     message("  no rows for the selected stations; skipped")


### PR DESCRIPTION
The previous run reported only 1 station with both gwl and gwq data, which is suspiciously few given that stations_gwq_master.json alone has 2706 lines and several entries with
Auspraegung == "GW-Stand + GW-Güte". Log the count at every intersection step (gwl_master, gwq_master, master_intersect, +gwl_data, +gwq_data) so the next run shows where stations drop out and we can fix the actual cause (likely a structural mismatch between master and data JSONs).

Also add an optional TB_HISTORY_DAYS env var (default 0 = all history) and a workflow_dispatch input set to '30' by default. The previous push of 8803 historical groundwater-level values returned an opaque HTTP 500 with empty body and no Content-Type, which strongly suggests upstream proxy / WAF rejection of bulk historical posts on the Maker free tier rather than an application-level error. Pushing only the last 30 days per station for now lets us confirm the rest of the pipeline works before fighting the historical-timestamp limit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/58)
<!-- Reviewable:end -->
