### PR TITLE
Surface ThingsBoard error body in tb_get_or_create_device too

### DIFF
--- a/.github/workflows/thingsboard-push.yaml
+++ b/.github/workflows/thingsboard-push.yaml
@@ -17,7 +17,7 @@ on:
       history_days:
         description: 'Push only the most recent N days per station (0 = all)'
         required: false
-        default: '365'
+        default: '0'
 
 name: thingsboard-push
 
@@ -29,7 +29,7 @@ jobs:
       TB_HOST: ${{ secrets.TB_HOST }}
       TB_API_KEY: ${{ secrets.TB_API_KEY }}
       TB_STATION_IDS: ${{ github.event.inputs.station_ids }}
-      TB_HISTORY_DAYS: ${{ github.event.inputs.history_days || '365' }}
+      TB_HISTORY_DAYS: ${{ github.event.inputs.history_days || '0' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -381,6 +381,7 @@ tb_get_or_create_device <- function(device_name, device_type, api_key, host)
       list(name = device_name, type = device_type),
       auto_unbox = TRUE
     ) |>
+    httr2::req_error(body = tb_error_body) |>
     httr2::req_perform() |>
     httr2::resp_body_json()
 
@@ -403,6 +404,7 @@ tb_get_device_access_token <- function(device_id, api_key, host)
     sprintf("%s/api/device/%s/credentials", host, device_id)
   ) |>
     httr2::req_headers(`X-Authorization` = paste("ApiKey", api_key)) |>
+    httr2::req_error(body = tb_error_body) |>
     httr2::req_perform() |>
     httr2::resp_body_json()
 


### PR DESCRIPTION
The previous run reached HTTP 403 inside tb_setup_devices() when trying to create the auto-selected top-5 stations. Most plausible cause is the Maker free tier's 5-device tenant limit being exceeded (one orphan device from earlier test runs plus five new candidates = 6). Wire tb_error_body() into the create-device and read-credentials calls so the next failure shows the JSON message that ThingsBoard returns instead of the generic
'HTTP 403 Forbidden'. The user can then decide whether to delete existing wasserportal-gw-* devices or upgrade the plan.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/60)
<!-- Reviewable:end -->
