### PR TITLE
Add 'single' telemetry mode to bypass Maker free tier 500s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,19 @@
   on the telemetry and attributes calls so future ThingsBoard
   failures surface the JSON `message` field in the R error instead
   of the generic "HTTP 500 Internal Server Error" wrapper
+* Add `tb_push_latest_telemetry()` for the simplest
+  `{"key": value}` form (server-stamped time). Used in
+  `inst/scripts/push_to_thingsboard.R` as a smoke test before the
+  bulk push: the bulk array-of-records form returns an opaque
+  HTTP 500 on the ThingsBoard Cloud Maker free tier even though
+  the same device accepts attribute writes and the simpler
+  per-record format
+* Add a `mode` parameter to `tb_push_station_telemetry()`
+  (`"single"` by default, `"bulk"` for self-hosted CE). Single mode
+  POSTs each record as a standalone `{"ts": ms, "values": {...}}`
+  object so historical telemetry actually goes through on Maker
+  free; bulk mode keeps the previous fast array-per-chunk
+  behaviour for self-hosted CE
 
 # [wasserportal 0.5.0](https://github.com/KWB-R/wasserportal/releases/tag/v0.5.0) <small>2026-05-07</small>
 

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -31,10 +31,14 @@
 #' @param host base URL of the ThingsBoard instance, without trailing slash.
 #'   Defaults to env var `TB_HOST` if set, otherwise
 #'   `"https://thingsboard.cloud"`.
-#' @param chunk_size maximum number of timestamps per HTTP POST. Default
-#'   `100`. Larger values trigger an opaque HTTP 500 from the
-#'   ThingsBoard Cloud Maker free tier; bumping this is safe on
-#'   self-hosted CE.
+#' @param chunk_size maximum number of timestamps per HTTP POST when
+#'   `mode = "bulk"`. Default `100`. Ignored in single mode.
+#' @param mode one of `"single"` (default) or `"bulk"`. The Maker free
+#'   tier on ThingsBoard Cloud rejects the bulk array form with an
+#'   opaque HTTP 500 even though the same device accepts the per-record
+#'   `{"ts": ms, "values": {...}}` object; single mode therefore POSTs
+#'   each record on its own. Use `"bulk"` against self-hosted CE for
+#'   the much faster array-of-records form.
 #' @param verbose print one line per chunk (default `TRUE`).
 #' @return invisibly the number of telemetry timestamps that were sent.
 #' @export
@@ -60,9 +64,12 @@ tb_push_station_telemetry <- function(
     single_key = "value",
     host = Sys.getenv("TB_HOST", unset = "https://thingsboard.cloud"),
     chunk_size = 100L,
+    mode = c("single", "bulk"),
     verbose = TRUE
 )
 {
+  mode <- match.arg(mode)
+
   stopifnot(
     is.data.frame(data),
     nzchar(device_token),
@@ -88,6 +95,28 @@ tb_push_station_telemetry <- function(
   url <- sprintf("%s/api/v1/%s/telemetry", sub("/+$", "", host), device_token)
 
   n <- length(payload)
+
+  if (mode == "single") {
+    # Send each record as a standalone `{"ts": ms, "values": {...}}` object,
+    # one per HTTP POST. Slower but the only format the ThingsBoard Cloud
+    # Maker free tier reliably accepts; the bulk array format returns an
+    # opaque HTTP 500 there.
+    for (i in seq_len(n)) {
+      httr2::request(url) |>
+        httr2::req_body_json(payload[[i]], auto_unbox = TRUE, digits = NA) |>
+        httr2::req_retry(max_tries = 4L, backoff = function(j) 2^j) |>
+        httr2::req_error(body = tb_error_body) |>
+        httr2::req_perform()
+
+      if (verbose && i %% 100L == 0L) {
+        message(sprintf("  POSTed %d/%d records", i, n))
+      }
+      Sys.sleep(0.05)  # ~20 req/sec safety throttle
+    }
+    return(invisible(n))
+  }
+
+  # mode == "bulk" -- works on self-hosted CE, fast.
   starts <- seq.int(1L, n, by = chunk_size)
 
   for (start in starts) {
@@ -107,10 +136,6 @@ tb_push_station_telemetry <- function(
       httr2::req_error(body = tb_error_body) |>
       httr2::req_perform()
 
-    # Throttle: stay safely below per-second message limits on
-    # ThingsBoard Cloud Maker (free) tier. 100 ms / chunk = 10 chunks
-    # per second, which is a few orders of magnitude under any
-    # documented limit and slow enough to avoid burst rejections.
     if (length(starts) > 1L) Sys.sleep(0.1)
   }
 

--- a/inst/scripts/push_to_thingsboard.R
+++ b/inst/scripts/push_to_thingsboard.R
@@ -37,6 +37,10 @@
 #                     (ThingsBoard Cloud free tier limit).
 #   TB_HISTORY_DAYS   Limit telemetry to the most recent N days per
 #                     station. Default 0 (= push all history).
+#   TB_TELEMETRY_MODE One of "single" (default) or "bulk". The Maker
+#                     free tier on ThingsBoard Cloud rejects bulk
+#                     arrays; switch to "bulk" only against
+#                     self-hosted CE.
 
 stopifnot(
   nzchar(Sys.getenv("TB_HOST")),
@@ -56,6 +60,12 @@ max_devices <- as.integer(Sys.getenv("TB_MAX_DEVICES", "5"))
 # all history. Useful while diagnosing whether the ThingsBoard Cloud free
 # tier silently rejects historical timestamps with HTTP 500.
 history_days <- as.integer(Sys.getenv("TB_HISTORY_DAYS", "0"))
+
+# Telemetry POST format. ThingsBoard Cloud Maker (free) tier returned an
+# opaque HTTP 500 to the bulk array-of-records form while accepting the
+# per-record object (smoke test passed for all five devices). Default to
+# the safer single-record mode; override to "bulk" against self-hosted CE.
+telemetry_mode <- Sys.getenv("TB_TELEMETRY_MODE", "single")
 
 read_json <- function(path) {
   jsonlite::fromJSON(paste0(base_url, "/", path))
@@ -339,7 +349,8 @@ push_telemetry_subset <- function(data, label) {
       ts_col       = "Datum",
       value_col    = "Messwert",
       key_col      = "Parameter",
-      verbose      = FALSE
+      mode         = telemetry_mode,
+      verbose      = TRUE
     )
     pushed <- pushed + nrow(one)
   }


### PR DESCRIPTION
The smoke test confirmed it: tb_push_latest_telemetry() succeeded for all five demo devices ('station 7044: latest GW-Stand = 29.07 ok' etc.) but the very next bulk POST -- the array-of-records form -- still returned HTTP 500 with empty body. ThingsBoard Cloud Maker free tier accepts the per-record object format ({ts, values}) and rejects the array form.

Add a mode parameter to tb_push_station_telemetry() with two strategies:
  * 'single' (new default): one HTTP POST per record, sending {ts, values} as a standalone JSON object. Slower (~50 ms sleep per record means ~20 records/s) but the only format the Maker free tier reliably accepts.
  * 'bulk': existing behaviour, sends arrays of chunk_size records. Fast against self-hosted CE.

Wire the script up to TB_TELEMETRY_MODE env var, default 'single'. Document the new flow and the smoke-test rationale in NEWS.md.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/62)
<!-- Reviewable:end -->
