### PR TITLE
Reset workflow plan default to 'free': bulk on Maker confirmed broken

### DIFF
--- a/.github/workflows/thingsboard-push.yaml
+++ b/.github/workflows/thingsboard-push.yaml
@@ -25,7 +25,7 @@ on:
       plan:
         description: 'ThingsBoard plan: free | free-bulk | prototype | pilot | startup | business | ce'
         required: false
-        default: 'free-bulk'
+        default: 'free'
 
 name: thingsboard-push
 
@@ -68,7 +68,7 @@ jobs:
       TB_STATION_IDS: ${{ github.event.inputs.station_ids || secrets.TB_STATION_IDS }}
       TB_HISTORY_DAYS: ${{ github.event.inputs.history_days || secrets.TB_HISTORY_DAYS || '0' }}
       TB_TELEMETRY_TYPES: ${{ github.event.inputs.telemetry_types || secrets.TB_TELEMETRY_TYPES || 'gwl,gwq' }}
-      TB_PLAN: ${{ github.event.inputs.plan || secrets.TB_PLAN || 'free-bulk' }}
+      TB_PLAN: ${{ github.event.inputs.plan || secrets.TB_PLAN || 'free' }}
       TB_TELEMETRY_MODE: ${{ secrets.TB_TELEMETRY_MODE }}
       TB_CHUNK_SIZE: ${{ secrets.TB_CHUNK_SIZE }}
       TB_THROTTLE_SECONDS: ${{ secrets.TB_THROTTLE_SECONDS }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,10 +69,14 @@
   from the per-device transport rate limits documented at
   <https://thingsboard.io/docs/paas/eu/subscriptions/>. Presets:
   `free` -> `single` mode (proven to work end-to-end on the Maker
-  free tier); `free-bulk` -> experimental bulk preset for Free
-  with `chunk_size = 10` / `throttle_seconds = 1.0` (10 dp/s,
-  well under the 100 dp/s burst cap that previously rejected the
-  array form); `prototype` / `pilot` / `startup` / `business` ->
+  free tier); `free-bulk` -> bulk preset for Free with
+  `chunk_size = 10` / `throttle_seconds = 1.0`; **confirmed not to
+  work** on the public Cloud Maker tier as of 2026-05 -- the
+  gateway returns the same empty-body HTTP 500 to a 10-record
+  array as it did to the original 100-record one, so the array
+  form is rejected regardless of payload size. Kept as a
+  reproducible baseline. `prototype` / `pilot` / `startup` /
+  `business` ->
   `bulk` with `chunk_size = 30` / `throttle_seconds = 1.0`
   (~30 dp/s, near the 2 000 dp/min per-device cap shared across
   all paid tiers); `ce` -> unlimited bulk for self-hosted
@@ -84,8 +88,10 @@
   `history_days`, `telemetry_types`) and document the
   workflow_dispatch input -> repository secret -> hardcoded
   default fallback chain in a header comment of the env block.
-  The default plan is now `free-bulk` so the next run tests the
-  faster bulk path on Free
+  The default plan is `free` (single mode, proven to work);
+  `free-bulk` is exposed as a workflow_dispatch option but stays
+  out of the cron path until ThingsBoard lifts the Maker
+  array-form rejection
 * Add `inst/extdata/thingsboard-dashboard.json`, an importable
   ThingsBoard dashboard for the demo: an OpenStreetMap markers map
   on the `latitude` / `longitude` attributes, a master-data

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -277,11 +277,13 @@ tb_push_station_attributes <- function(
 #' @param plan one of
 #'   * `"free"` -- proven Single-record mode (`mode = "single"`,
 #'     `chunk_size = 1`, `throttle_seconds = 0.05`).
-#'   * `"free-bulk"` -- experimental Bulk mode tuned to stay under
-#'     Free's per-device 100 dp/s and 2,000 dp/min caps
-#'     (`chunk_size = 10`, `throttle_seconds = 1.0`); a previous
-#'     bulk attempt at 1,000 dp/s burst was rejected with an empty
-#'     500, so test on a small history before relying on it.
+#'   * `"free-bulk"` -- bulk preset tuned to stay under Free's
+#'     per-device 100 dp/s and 2,000 dp/min caps (`chunk_size = 10`,
+#'     `throttle_seconds = 1.0`). Confirmed not to work on the
+#'     public ThingsBoard Cloud Maker free tier as of 2026-05: the
+#'     gateway returns an opaque empty-body HTTP 500 to the array
+#'     form regardless of how small the chunk is. Kept as a
+#'     reproducible baseline; on Free use `"free"`.
 #'   * `"prototype"`, `"pilot"`, `"startup"`, `"business"` -- the
 #'     paid PaaS tiers. All use `mode = "bulk"`,
 #'     `chunk_size = 30`, `throttle_seconds = 1.0` (~30 dp/s,
@@ -307,14 +309,16 @@ tb_plan_defaults <- function(plan = "free")
       throttle_seconds = 0.05
     ),
     `free-bulk` = list(
-      # Untested. ThingsBoard Cloud Free's per-device limits suggest
-      # bulk should fit at 10 data points per second sustained, but the
-      # only previous bulk attempt used chunk_size=100 + throttle=0.1s
-      # (= 1000 dp/s burst, 10x above Free's 100/sec) and was rejected
-      # with an empty-body HTTP 500. The 500 may have been a proxy-level
-      # reject of the array form rather than a rate-limit response, in
-      # which case smaller chunks will not help -- run a small test
-      # before relying on it.
+      # Confirmed not to work on the public ThingsBoard Cloud Maker
+      # free tier as of 2026-05: even chunk_size=10 + throttle=1.0s
+      # (10 dp/s, well under the documented 100 dp/s burst and
+      # 2,000 dp/min sustained per-device caps) returns the same
+      # opaque empty-body HTTP 500 as the original 100-record
+      # attempt. The Maker plan apparently rejects the array form
+      # at the gateway irrespective of payload size; single mode
+      # remains the only reliable shape on Free. The preset is kept
+      # so the experiment is reproducible and so it can serve as a
+      # baseline if ThingsBoard ever lifts the restriction.
       mode = "bulk",
       chunk_size = 10L,
       throttle_seconds = 1.0

--- a/man/tb_plan_defaults.Rd
+++ b/man/tb_plan_defaults.Rd
@@ -11,11 +11,14 @@ tb_plan_defaults(plan = "free")
 \itemize{
   \item \code{"free"} -- proven Single-record mode (\code{mode = "single"},
     \code{chunk_size = 1}, \code{throttle_seconds = 0.05}).
-  \item \code{"free-bulk"} -- experimental Bulk mode tuned to stay under
+  \item \code{"free-bulk"} -- bulk preset tuned to stay under
     Free's per-device 100 dp/s and 2,000 dp/min caps
-    (\code{chunk_size = 10}, \code{throttle_seconds = 1.0}); a previous
-    bulk attempt at 1,000 dp/s burst was rejected with an empty
-    500, so test on a small history before relying on it.
+    (\code{chunk_size = 10}, \code{throttle_seconds = 1.0}).
+    Confirmed not to work on the public ThingsBoard Cloud Maker
+    free tier as of 2026-05: the gateway returns an opaque
+    empty-body HTTP 500 to the array form regardless of how small
+    the chunk is. Kept as a reproducible baseline; on Free use
+    \code{"free"}.
   \item \code{"prototype"}, \code{"pilot"}, \code{"startup"}, \code{"business"} -- the
     paid PaaS tiers. All use \code{mode = "bulk"},
     \code{chunk_size = 30}, \code{throttle_seconds = 1.0} (~30 dp/s,


### PR DESCRIPTION
## Summary

Reverts the `free-bulk` workflow default back to `free` after the latest run conclusively confirmed bulk doesn't work on the ThingsBoard Cloud Maker free tier.

## Why

The previous PR (#64) shipped the `env_or()` fix that made the plan-derived defaults actually arrive at `tb_push_station_telemetry()` (chunk_size=10, throttle_seconds=1, mode=bulk for `free-bulk`). The follow-up run got past
- env wiring ✅
- master/data load ✅
- smoke test (5/5) ✅
- and immediately hit the same opaque `HTTP 500 (empty body)` on the very first 10-record bulk POST.

Since the original 100-record array hit the same response and the safe 10-record array also hits it, Maker rejects the array form at the gateway regardless of payload size or rate. Single mode (proven over the 4 h GWL backfill) remains the only working shape on Free.

## What changed

- Workflow `plan` default and `TB_PLAN` env fallback reset to `free`. `free-bulk` stays as a `workflow_dispatch` option for reproduction.
- `tb_plan_defaults()` docstring (R + Rd) for `free-bulk` now reads "confirmed not to work on Cloud Maker as of 2026-05" with a kept-as-baseline rationale.
- NEWS.md updated to record the negative empirical finding.

## Test plan

- [ ] Trigger `thingsboard-push` with the new `plan=free` default and confirm the GWQ push proceeds in single mode without HTTP 500.

https://claude.ai/code/session_019KUVy2LFtUPxrgM3T9mcCL

---
_Generated by [Claude Code](https://claude.ai/code/session_019KUVy2LFtUPxrgM3T9mcCL)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/65)
<!-- Reviewable:end -->
