### PR TITLE
Send one (ts,key,value) per record in single mode so GWQ pushes through Maker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,16 @@
   dashboard-level timewindow defaults to a 365-day history (not
   the realtime sliding window) so charts show the full backfill
   immediately after import
+* Send one telemetry record per `(timestamp, key, value)` triple in
+  `mode = "single"` instead of grouping every Parameter that
+  shares a timestamp into a single record. Wasserportal
+  groundwater quality data has ~30 analytes per sampling event;
+  the resulting "fat" `values` dicts produced an opaque empty-body
+  HTTP 500 on Cloud Maker even though the same keys went through
+  one at a time (see `tb_push_latest_telemetry()` smoke tests).
+  `build_telemetry_payload()` gains a `group_by_ts` parameter
+  (default `TRUE`); the push function flips it off in single mode
+  and keeps grouping in bulk mode for compact array chunks
 * Sanitise telemetry keys before serialising the values dict.
   Wasserportal groundwater quality parameters such as
   `Leitfaehigkeit 25 grd C vor Ort`, `Wasserst. (ROK) vor`,

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -103,7 +103,14 @@ tb_push_station_telemetry <- function(
     ts_col = ts_col,
     value_col = value_col,
     key_col = key_col,
-    single_key = single_key
+    single_key = single_key,
+    # In single mode keep one (ts, key, value) per record -- otherwise
+    # ThingsBoard Cloud Maker rejects the "fat" values dict produced
+    # when many parameters share a timestamp (groundwater quality
+    # often has 30+ analytes per sampling event) with an opaque
+    # empty-body HTTP 500. In bulk mode keep grouping so each chunk
+    # POST stays compact.
+    group_by_ts = mode != "single"
   )
 
   url <- sprintf("%s/api/v1/%s/telemetry", sub("/+$", "", host), device_token)
@@ -421,11 +428,20 @@ tb_push_latest_telemetry <- function(
 #' @param value_col value column name.
 #' @param key_col key column name or `NULL`.
 #' @param single_key telemetry key used when `key_col` is `NULL`.
+#' @param group_by_ts when `TRUE` (default), several rows that share
+#'   the same timestamp are merged into a single record whose
+#'   `values` dict carries every Parameter measured at that point in
+#'   time. Set to `FALSE` to keep one record per row -- ThingsBoard
+#'   Cloud Maker rejects "fat" `values` dicts (the ~30-key
+#'   groundwater-quality records hit an opaque HTTP 500 even though
+#'   each individual key works on its own), so the script flips this
+#'   off in single mode.
 #' @return list of `list(ts = <numeric ms>, values = list(<key> = <value>))`.
 #' @keywords internal
 #' @noRd
 build_telemetry_payload <- function(
-    data, ts_col, value_col, key_col, single_key
+    data, ts_col, value_col, key_col, single_key,
+    group_by_ts = TRUE
 )
 {
   ts_ms <- to_epoch_ms(data[[ts_col]])
@@ -450,12 +466,19 @@ build_telemetry_payload <- function(
   }
   keys <- sanitize_tb_key(keys)
 
-  # Group by timestamp so that several Parameter values that share the same
-  # Datum end up in one ThingsBoard telemetry record.
   ord <- order(ts_ms)
   ts_ms <- ts_ms[ord]
   values <- values[ord]
   keys   <- keys[ord]
+
+  if (!group_by_ts) {
+    return(lapply(seq_along(ts_ms), function(i) {
+      list(
+        ts = ts_ms[i],
+        values = stats::setNames(list(values[i]), keys[i])
+      )
+    }))
+  }
 
   splits <- split(seq_along(ts_ms), ts_ms)
 


### PR DESCRIPTION
## Summary

Final fix for the groundwater quality push on ThingsBoard Cloud Maker free tier: stop merging multiple Parameters that share a timestamp into one "fat" telemetry record.

## Why

After the previous PRs landed (env_or fix, plan=free default), the next run still failed on the very first GWQ record with the now-familiar opaque empty-body HTTP 500 — even though the same `plan=free, mode=single` configuration successfully pushed 66 k GWL records over four hours.

Comparing the two datasets:

| | Parameters per timestamp | `values` dict size |
|---|---|---|
| GWL | 1 (`GW-Stand`) | 1 key |
| GWQ | ~30 analytes per sampling event | ~30 keys |

Cloud Maker apparently rejects the resulting multi-key `{ts, values}` record at the gateway, even though each individual key works in isolation (the `tb_push_latest_telemetry()` smoke tests confirmed every key succeeds when sent alone).

## What changed

* `build_telemetry_payload()` gains a `group_by_ts` parameter (default `TRUE` so existing callers keep their behaviour).
* `tb_push_station_telemetry(mode = "single")` flips `group_by_ts` to `FALSE` so each row of the source data frame becomes its own `{ts, values: {key: value}}` record. Bulk mode keeps grouping for compact array chunks (still useful against self-hosted CE).
* NEWS.md notes the empirical reason and the new parameter.

## Test plan

- [ ] Trigger `thingsboard-push` with `plan=free`, `telemetry_types=gwq` and confirm the first GWQ record no longer 500s.
- [ ] Confirm GWQ data shows up in the ThingsBoard time-series widget for at least one station (e.g. station 6038's `Nitrat` / `Chlorid`).

https://claude.ai/code/session_019KUVy2LFtUPxrgM3T9mcCL

---
_Generated by [Claude Code](https://claude.ai/code/session_019KUVy2LFtUPxrgM3T9mcCL)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/66)
<!-- Reviewable:end -->
