### PR TITLE
Pace parallel single-mode pushes per max_active group, retry on 500

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,12 +106,15 @@
   The previous sequential one-POST-at-a-time loop was network-bound
   at ~1.2 records/s for the GWQ push (~5 h per station for the full
   history); concurrent posting with `max_active = 10` lifts that to
-  ~10 records/s while staying below the Free tier's 50 msg/s
-  per-device transport rate limit. `tb_push_station_telemetry()`
-  gains a `max_active` parameter; `tb_plan_defaults()` returns it
-  per plan (default `10` for Free, `1` elsewhere); the script
-  reads `TB_MAX_ACTIVE` from env / repo secrets through the same
-  `env_or()` plan-fallback chain
+  ~10 records/s. `tb_push_station_telemetry()` gains a `max_active`
+  parameter; `tb_plan_defaults()` returns it per plan (default `10`
+  for Free, `1` elsewhere); the script reads `TB_MAX_ACTIVE` from
+  env / repo secrets through the same `env_or()` plan-fallback chain.
+  Pace concurrent batches one-`max_active`-group at a time and retry
+  on transient HTTP 500/502/503/504 with exponential backoff, so the
+  Free tier's 600 messages/minute sustained per-device limit doesn't
+  trip the gateway after ~35 s at 48 records/s (the symptom we hit
+  with the initial implementation)
 * Send one telemetry record per `(timestamp, key, value)` triple in
   `mode = "single"` instead of grouping every Parameter that
   shares a timestamp into a single record. Wasserportal

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -131,17 +131,27 @@ tb_push_station_telemetry <- function(
     # Sequential single POSTs are network-bound (~700 ms per request once
     # TLS, server processing and TB's retry overhead are added up). To
     # reclaim that latency we send `max_active` requests concurrently via
-    # httr2::req_perform_parallel(); the per-device 50 messages/second
-    # transport rate limit on the Free tier still leaves headroom for
-    # max_active = 10. Throttle, if requested, applies between batches.
+    # httr2::req_perform_parallel(); the batch size matches max_active so
+    # `throttle_seconds` paces *every* group of concurrent requests, not
+    # only every Nth batch -- otherwise even max_active = 10 quickly
+    # overshoots Free's 600 messages/minute per-device sustained limit.
+    # is_transient is widened so the inevitable 500s from rate-limit
+    # bursts get retried with exponential backoff.
+    is_transient_500 <- function(resp) {
+      httr2::resp_status(resp) %in% c(408L, 429L, 500L, 502L, 503L, 504L)
+    }
     reqs <- lapply(payload, function(record) {
       httr2::request(url) |>
         httr2::req_body_json(record, auto_unbox = TRUE, digits = NA) |>
-        httr2::req_retry(max_tries = 4L, backoff = function(j) 2^j) |>
+        httr2::req_retry(
+          max_tries = 4L,
+          backoff = function(j) 2^j,
+          is_transient = is_transient_500
+        ) |>
         httr2::req_error(body = tb_error_body)
     })
 
-    batch_size <- max(max_active * 10L, 1L)
+    batch_size <- max(max_active, 1L)
     starts <- seq.int(1L, n, by = batch_size)
 
     for (start in starts) {
@@ -339,7 +349,7 @@ tb_plan_defaults <- function(plan = "free")
     free = list(
       mode = "single",
       chunk_size = 1L,
-      throttle_seconds = 0.05,
+      throttle_seconds = 1.0,
       max_active = 10L
     ),
     `free-bulk` = list(


### PR DESCRIPTION
The first parallel run sailed through 1700 GWQ records at ~48 records/s before tripping the Free tier's 600 messages/minute per-device sustained limit (10/s averaged) and getting an empty-body HTTP 500 from the gateway. Fix it with three small changes:

* Drop batch_size from max_active * 10 (= 100 records) to max_active (= 10 records). throttle_seconds now paces every group of concurrent requests, so the average stays at max_active records per (concurrent_time + throttle).
* Bump tb_plan_defaults('free')$throttle_seconds from 0.05 to 1.0: with max_active = 10 and ~0.7 s per concurrent batch this targets ~6 records/s sustained, well under the documented 10/s sustained per-device cap.
* Widen is_transient in req_retry() so 500/502/503/504 are also retried with exponential backoff. The empty-body 500 we get from rate-limit bursts is therefore absorbed transparently in most cases rather than aborting the whole push.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/68)
<!-- Reviewable:end -->
