### PR TITLE
Retry on TCP/TLS transport errors during long telemetry pushes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # wasserportal 0.5.0.9000 <small>(development version)</small>
 
+* Pass `retry_on_failure = TRUE` to every `httr2::req_retry()` call
+  in `R/push_to_thingsboard.R` (single-mode and bulk telemetry,
+  attributes, latest telemetry, telemetry delete). The default
+  `req_retry()` only retries HTTP responses with selected status
+  codes; transport-layer dropouts that error out before the request
+  produces a response (TCP "Broken pipe", peer-closed TLS session,
+  brief DNS hiccups) used to bubble straight up through
+  `httr2::req_perform_parallel()` and abort the whole station mid
+  push -- observed in the wild after ~25 min on station 7044 at
+  record ~9030/13362. With `retry_on_failure = TRUE` the same record
+  gets retried up to four times with the existing exponential
+  backoff (2, 4, 8, 16 s), and because ThingsBoard de-duplicates by
+  `(ts, key)` the retry never produces a duplicate row even when the
+  first attempt actually reached the server before the connection
+  dropped.
+
 * Add `tb_setup_devices()`, `tb_push_station_telemetry()` and
   `tb_push_station_attributes()` for shipping Wasserportal time series
   and master data into a ThingsBoard tenant via the device-token

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -136,7 +136,12 @@ tb_push_station_telemetry <- function(
     # only every Nth batch -- otherwise even max_active = 10 quickly
     # overshoots Free's 600 messages/minute per-device sustained limit.
     # is_transient is widened so the inevitable 500s from rate-limit
-    # bursts get retried with exponential backoff.
+    # bursts get retried with exponential backoff, and retry_on_failure
+    # is enabled so transport-layer dropouts (TCP "Broken pipe",
+    # peer-closed TLS session, brief DNS hiccups) on a 25 min push
+    # also get retried instead of aborting the rest of the batch.
+    # All ThingsBoard telemetry POSTs are idempotent on (ts, key) so
+    # a retried record never duplicates data.
     is_transient_500 <- function(resp) {
       httr2::resp_status(resp) %in% c(408L, 429L, 500L, 502L, 503L, 504L)
     }
@@ -144,9 +149,10 @@ tb_push_station_telemetry <- function(
       httr2::request(url) |>
         httr2::req_body_json(record, auto_unbox = TRUE, digits = NA) |>
         httr2::req_retry(
-          max_tries = 4L,
-          backoff = function(j) 2^j,
-          is_transient = is_transient_500
+          max_tries        = 4L,
+          backoff          = function(j) 2^j,
+          is_transient     = is_transient_500,
+          retry_on_failure = TRUE
         ) |>
         httr2::req_error(body = tb_error_body)
     })
@@ -189,7 +195,7 @@ tb_push_station_telemetry <- function(
 
     httr2::request(url) |>
       httr2::req_body_json(chunk, auto_unbox = TRUE, digits = NA) |>
-      httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i) |>
+      httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i, retry_on_failure = TRUE) |>
       httr2::req_error(body = tb_error_body) |>
       httr2::req_perform()
 
@@ -289,7 +295,7 @@ tb_push_station_attributes <- function(
 
   httr2::request(url) |>
     httr2::req_body_json(attributes, auto_unbox = TRUE, digits = NA) |>
-    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i) |>
+    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i, retry_on_failure = TRUE) |>
     httr2::req_error(body = tb_error_body) |>
     httr2::req_perform()
 
@@ -451,7 +457,7 @@ tb_push_latest_telemetry <- function(
 
   httr2::request(url) |>
     httr2::req_body_json(values, auto_unbox = TRUE, digits = NA) |>
-    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i) |>
+    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i, retry_on_failure = TRUE) |>
     httr2::req_error(body = tb_error_body) |>
     httr2::req_perform()
 
@@ -762,7 +768,7 @@ tb_delete_device_telemetry <- function(
       deleteAllDataForKeys = "true",
       deleteLatest = if (delete_latest) "true" else "false"
     ) |>
-    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i) |>
+    httr2::req_retry(max_tries = 4L, backoff = function(i) 2^i, retry_on_failure = TRUE) |>
     httr2::req_error(body = tb_error_body) |>
     httr2::req_perform()
 


### PR DESCRIPTION
httr2::req_retry() by default only retries HTTP responses with selected status codes; transport-layer dropouts that error out before the request produces a response (TCP "Broken pipe", peer-closed TLS session) bubble straight up through req_perform_parallel() and abort the whole station mid push. Observed in the wild after ~25 min on station 7044 at record ~9030/13362:

  Error in `httr2::req_perform_parallel()`:
  ! Failed to perform HTTP request.
  Caused by error:
  ! Failed sending data to the peer [eu.thingsboard.cloud]:
  Send failure: Broken pipe

Pass retry_on_failure = TRUE to every req_retry() call in R/push_to_thingsboard.R (single-mode and bulk telemetry, attributes, latest telemetry, telemetry delete). All five touch endpoints where the operation is idempotent on the server side ((ts, key) overwrite, attribute last-write-wins, delete-by-key), so retrying a record never produces a duplicate row even if the first attempt actually reached ThingsBoard before the TLS connection dropped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/72)
<!-- Reviewable:end -->
