### PR TITLE
Retry req_perform_parallel batch on libcurl pool poison

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # wasserportal 0.5.0.9000 <small>(development version)</small>
 
+* Wrap each `httr2::req_perform_parallel()` batch in
+  `tb_push_station_telemetry()` `mode = "single"` in a batch-level
+  retry loop (4 attempts with `2 / 4 / 8 s` backoff). The per-request
+  `retry_on_failure = TRUE` added in the previous bullet recovers
+  from a curl-level error on a *fresh* libcurl handle, but when the
+  upstream load balancer silently drops a connection in the curl
+  pool the dead handle stays poisoned across all four configured
+  per-request retries: every retry hits the same dead handle and
+  dies with "Send failure: Broken pipe" within milliseconds, the
+  resulting curl condition bubbles up through `req_perform_parallel()`
+  and aborts the whole station (observed in the wild after only
+  ~2240/13039 records on station 7045 on 2026-05-13 09:45,
+  3 s between last good POST and the abort -- no perceptible
+  retry pause). Retrying the *batch* as a whole forces httr2 to
+  allocate a new connection on the next attempt and is safe because
+  the underlying `(ts, key)` telemetry POSTs are idempotent on the
+  ThingsBoard side -- a re-POST of an already accepted record
+  overwrites itself with the same value, never creates a duplicate
+  row.
 * Pass `retry_on_failure = TRUE` to every `httr2::req_retry()` call
   in `R/push_to_thingsboard.R` (single-mode and bulk telemetry,
   attributes, latest telemetry, telemetry delete). The default

--- a/R/push_to_thingsboard.R
+++ b/R/push_to_thingsboard.R
@@ -159,14 +159,50 @@ tb_push_station_telemetry <- function(
 
     batch_size <- max(max_active, 1L)
     starts <- seq.int(1L, n, by = batch_size)
+    batch_max_tries <- 4L
 
     for (start in starts) {
       end <- min(start + batch_size - 1L, n)
-      httr2::req_perform_parallel(
-        reqs[start:end],
-        max_active = max_active,
-        progress = FALSE
-      )
+      batch_reqs <- reqs[start:end]
+
+      # Wrap the parallel batch in a retry loop. The per-request
+      # `retry_on_failure = TRUE` inside req_retry() recovers from a
+      # transient HTTP/curl error on a *fresh* libcurl handle, but the
+      # connection-pool entry that the upstream gateway has silently
+      # dropped stays poisoned across all four configured per-request
+      # retries: every retry hits the same dead handle and dies with
+      # "Send failure: Broken pipe" within milliseconds. The result is
+      # a curl error that bubbles up through req_perform_parallel() and
+      # aborts the whole batch. Retrying the *batch* as a whole forces
+      # httr2 to allocate a new connection on the next attempt and is
+      # safe because the underlying (ts, key) telemetry POSTs are
+      # idempotent on the ThingsBoard side -- a re-POST of an already
+      # accepted record overwrites itself with the same value, never
+      # creates a duplicate row.
+      for (batch_try in seq_len(batch_max_tries)) {
+        batch_ok <- tryCatch({
+          httr2::req_perform_parallel(
+            batch_reqs,
+            max_active = max_active,
+            progress   = FALSE
+          )
+          TRUE
+        }, error = function(e) {
+          if (batch_try < batch_max_tries) {
+            wait <- 2^batch_try
+            message(sprintf(
+              "  batch %d-%d failed (%s); batch retry %d/%d in %g s",
+              start, end, conditionMessage(e),
+              batch_try, batch_max_tries - 1L, wait
+            ))
+            Sys.sleep(wait)
+            FALSE
+          } else {
+            stop(e)
+          }
+        })
+        if (isTRUE(batch_ok)) break
+      }
 
       if (verbose) {
         message(sprintf(


### PR DESCRIPTION
When the upstream eu.thingsboard.cloud load balancer silently drops a connection in libcurl's pool, the dead handle stays poisoned across all four configured per-request retries (every retry hits the same handle and dies within milliseconds with "Send failure: Broken pipe"). The resulting curl condition bubbles up through req_perform_parallel() and aborts the whole station push -- observed in the wild after only ~2240/13039 records on station 7045 on 2026-05-13 09:45, with just 3 s between last good POST and the abort (no perceptible retry pause).

Wrap each req_perform_parallel() batch in tb_push_station_telemetry() single mode in a top-level retry loop (4 attempts, 2/4/8 s backoff). Retrying the batch as a whole forces httr2 to allocate a new connection on the next attempt and is safe because the underlying (ts, key) telemetry POSTs are idempotent on the ThingsBoard side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/73)
<!-- Reviewable:end -->
