### PR TITLE
Release wasserportal 0.6.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wasserportal
 Title: R Package with Functions for Scraping Data of Wasserportal Berlin
-Version: 0.5.0.9000
+Version: 0.6.0
 Authors@R: c(
     person("Hauke", "Sonnenberg", , "hauke.sonnenberg@kompetenz-wasser.de", role = "aut",
            comment = c(ORCID = "0000-0001-9134-2871")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# wasserportal 0.5.0.9000 <small>(development version)</small>
+# [wasserportal 0.6.0](https://github.com/KWB-R/wasserportal/releases/tag/v0.6.0) <small>2026-06-17</small>
 
 * Wrap each `httr2::req_perform_parallel()` batch in
   `tb_push_station_telemetry()` `mode = "single"` in a batch-level


### PR DESCRIPTION
Bump Version from 0.5.0.9000 to 0.6.0 and turn the NEWS.md development heading into the 0.6.0 release heading (dated 2026-06-17), collecting all changes accumulated since v0.5.0 -- chiefly the ThingsBoard telemetry / attribute push workflow, the groundwater dashboard, and the parallel-push transport-retry hardening.


Claude-Session: https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/74)
<!-- Reviewable:end -->
