### PR TITLE
Declare R (>= 4.1.0), drop LazyData, set 0.7.0 release date

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,8 @@ Description: R Package with Functions for Scraping Data of Wasserportal
 License: MIT + file LICENSE
 URL: https://github.com/KWB-R/wasserportal
 BugReports: https://github.com/KWB-R/wasserportal/issues
+Depends:
+    R (>= 4.1.0)
 Imports: 
     archive,
     data.table,
@@ -63,6 +65,5 @@ Remotes:
     github::kwb-r/kwb.utils
 Config/testthat/edition: 3
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# [wasserportal 0.7.0](https://github.com/KWB-R/wasserportal/releases/tag/v0.7.0) <small>2026-06-17</small>
+# [wasserportal 0.7.0](https://github.com/KWB-R/wasserportal/releases/tag/v0.7.0) <small>2026-06-18</small>
 
 * Add `tb_login()` and username/password (JWT) authentication across the
   ThingsBoard tenant-API helpers (`tb_setup_devices()`,


### PR DESCRIPTION
- Add Depends: R (>= 4.1.0): inst/scripts code and R/push_to_thingsboard.R use the native pipe |>, which R CMD check otherwise flags as an undeclared dependency.
- Remove LazyData: true (no data/ directory, R CMD build omitted it).
- NEWS: set the wasserportal 0.7.0 release date to 2026-06-18.


Claude-Session: https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/77)
<!-- Reviewable:end -->
