### PR TITLE
Fail-fast on bad TB_* env vars + document R (>= 4.1.0) in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,14 @@
   self-hosted instances whose reverse proxy echoes request fields back
   in the error body should mask the relevant secrets in their CI
   config.
+* Validate the numeric `TB_*` environment variables (`TB_MAX_DEVICES`,
+  `TB_HISTORY_DAYS`, `TB_CHUNK_SIZE`, `TB_THROTTLE_SECONDS`,
+  `TB_MAX_ACTIVE`) up front in `inst/scripts/push_to_thingsboard.R` and
+  abort with a clear message when a value is not a number, instead of
+  letting an `NA` crash a downstream `if (x > 0)` only after every device
+  attribute set has already been pushed. The message points out the usual
+  cause: `.Renviron` does not support inline `# comments`, so
+  `TB_HISTORY_DAYS = 7  # ...` otherwise coerces to `NA`.
 
 # [wasserportal 0.6.0](https://github.com/KWB-R/wasserportal/releases/tag/v0.6.0) <small>2026-06-17</small>
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,11 @@
 * Update the Kompetenzzentrum Wasser Berlin (KWB) author logo in
   `_pkgdown.yml` to the new brand asset
   (`logos.kompetenz-wasser.io/KWB_Logo_M_Blau_RGB.svg`).
+* Declare `Depends: R (>= 4.1.0)` -- the package (notably
+  `R/push_to_thingsboard.R` and `inst/scripts/push_to_thingsboard.R`) uses
+  the native `|>` pipe, which `R CMD check` otherwise flags as an
+  undeclared dependency -- and drop the unused `LazyData` field (there is
+  no `data/` directory, so `R CMD build` omitted it anyway).
 * Warn in `tb_auth_header()` when only one of `TB_USERNAME` /
   `TB_PASSWORD` is set and a leftover `TB_API_KEY` causes a silent
   fallback to the Cloud API-key path. The typical misconfiguration

--- a/inst/scripts/push_to_thingsboard.R
+++ b/inst/scripts/push_to_thingsboard.R
@@ -77,6 +77,26 @@ env_or <- function(name, default) {
   if (nzchar(v)) v else default
 }
 
+# Parse a numeric/integer env var, failing fast with a clear message rather
+# than letting an NA crash a downstream `if (x > 0)` after a long push.
+# NB: .Renviron does NOT support inline `# comments` -- e.g.
+# `TB_HISTORY_DAYS = 7  # foo` sets the value to "7  # foo", which coerces to
+# NA here; put any such comment on its own line.
+num_env <- function(name, default, integer = FALSE) {
+  raw <- env_or(name, default)
+  val <- suppressWarnings(if (integer) as.integer(raw) else as.numeric(raw))
+  if (is.na(val)) {
+    stop(sprintf(
+      paste0(
+        "%s must be %s, got '%s'. Note: .Renviron does not support inline ",
+        "'# comments' -- put any comment on its own line."
+      ),
+      name, if (integer) "an integer" else "numeric", raw
+    ), call. = FALSE)
+  }
+  val
+}
+
 if (!nzchar(Sys.getenv("TB_HOST"))) {
   stop(paste0(
     "TB_HOST is required (e.g. https://eu.thingsboard.cloud or ",
@@ -111,7 +131,7 @@ device_prefix <- env_or("TB_DEVICE_PREFIX", "wasserportal-gw-")
 
 # Maximum number of devices/stations to set up. 0 (or negative) = no limit
 # (push every candidate station -- only sensible on self-hosted / paid tiers).
-max_devices <- as.integer(env_or("TB_MAX_DEVICES", "5"))
+max_devices <- num_env("TB_MAX_DEVICES", "5", integer = TRUE)
 
 # Candidate pool for the auto-pick (used only when TB_STATION_IDS is unset):
 # "both" (default) = level AND quality; "any" = level OR quality;
@@ -122,7 +142,7 @@ station_scope <- tolower(env_or("TB_STATION_SCOPE", "both"))
 # Limit telemetry to the most recent N days per station. Set to 0 to push
 # all history. Useful while diagnosing whether the ThingsBoard Cloud free
 # tier silently rejects historical timestamps with HTTP 500.
-history_days <- as.integer(env_or("TB_HISTORY_DAYS", "0"))
+history_days <- num_env("TB_HISTORY_DAYS", "0", integer = TRUE)
 
 # Resolve push tunables from the ThingsBoard plan via tb_plan_defaults().
 # TB_PLAN takes precedence; individual TB_TELEMETRY_MODE / TB_CHUNK_SIZE /
@@ -133,19 +153,20 @@ plan_defaults <- wasserportal::tb_plan_defaults(
   env_or("TB_PLAN", "free")
 )
 telemetry_mode <- env_or("TB_TELEMETRY_MODE", plan_defaults$mode)
-chunk_size <- as.integer(env_or(
+chunk_size <- num_env(
   "TB_CHUNK_SIZE",
-  as.character(plan_defaults$chunk_size)
-))
-throttle_seconds <- as.numeric(env_or(
+  as.character(plan_defaults$chunk_size),
+  integer = TRUE
+)
+throttle_seconds <- num_env(
   "TB_THROTTLE_SECONDS",
   as.character(plan_defaults$throttle_seconds)
-))
+)
 plan_max_active <- if (is.null(plan_defaults$max_active)) 10L else
   plan_defaults$max_active
-max_active <- as.integer(env_or(
-  "TB_MAX_ACTIVE", as.character(plan_max_active)
-))
+max_active <- num_env(
+  "TB_MAX_ACTIVE", as.character(plan_max_active), integer = TRUE
+)
 
 message(sprintf(
   paste0(


### PR DESCRIPTION
Final touches on the 0.7.0 ThingsBoard push work, on top of what is already merged into `dev`.

## Changes

**Fail fast on non-numeric `TB_*` env vars** (`inst/scripts/push_to_thingsboard.R`)
- `TB_MAX_DEVICES`, `TB_HISTORY_DAYS`, `TB_CHUNK_SIZE`, `TB_THROTTLE_SECONDS` and `TB_MAX_ACTIVE` now go through a `num_env()` helper that aborts up front with a clear message when a value is not a number, instead of letting an `NA` from `as.integer()` / `as.numeric()` crash a downstream `if (x > 0)` — which previously happened only *after* every device's attributes had already been pushed.
- The error message flags the usual cause: `.Renviron` does not support inline `# comments`, so e.g. `TB_HISTORY_DAYS = 7  # foo` coerces to `NA`.

**Document `R (>= 4.1.0)` / `LazyData` in NEWS** (`NEWS.md`)
- Adds the changelog entry for the `Depends: R (>= 4.1.0)` bump and `LazyData` removal so the 0.7.0 NEWS section matches the planned GitHub release notes.

## Notes
- Robustness + changelog only; no functional change to the auth or push logic.
- After merge, `dev` is ready to tag `v0.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/79)
<!-- Reviewable:end -->
