### PR TITLE
Allow bot-initiated PRs in Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -24,6 +24,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The action blocks non-human actors by default; a PR opened or
+          # synchronized by claude[bot] therefore failed with
+          # "Workflow initiated by non-human actor". Allow bots to trigger
+          # the review. Narrow "*" to a specific login (e.g. "claude[bot]")
+          # to restrict which bots qualify.
+          allowed_bots: "*"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow fails on PRs that are opened or synchronized by `claude[bot]` (e.g. the `claude[bot]` sync PRs against `dev`):

```
Action failed with error: Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action@v1` blocks non-human actors by default, so the check goes red even though nothing is wrong with the code.

## Fix

Add `allowed_bots: "*"` to the action inputs in `.github/workflows/claude-code-review.yaml` so bot-driven `pull_request` events run the review instead of failing. An inline comment notes how to narrow `"*"` to a specific login (e.g. `"claude[bot]"`).

## Notes

- `pull_request` workflows use the workflow file from the **PR head branch**, so this takes effect for PRs branched from `dev` after the merge; an already-open failing PR needs its head branch re-synced from `dev` before the check turns green.
- Alternative, if bot PRs should not be reviewed at all: gate the job with `if: github.event.pull_request.user.type != 'Bot'` to skip (rather than fail) bot-initiated runs. Happy to switch to that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5oA36vi7m6DSkah3tc5eo)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KWB-R/wasserportal/80)
<!-- Reviewable:end -->
